### PR TITLE
feature/takes-api-endpoints.

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import { errorHandler } from './middleware/error-handler';
 import authRouter from './routes/auth-routes';
 import usersRouter from './routes/user-routes';
 import roleRouter from './routes/role-routes';
+import { createTakeRouter } from './routes/take-route';
 import prisma from './prisma';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
@@ -25,6 +26,7 @@ const API_VERSION = '/api/v1';
 app.use(`${API_VERSION}/auth`, authRouter);
 app.use(`${API_VERSION}/users`, usersRouter);
 app.use(`${API_VERSION}/roles`, roleRouter);
+app.use(`${API_VERSION}/takes`, createTakeRouter(prisma));
 
 app.get('/', (_, res) => {
   res.json({

--- a/server/src/controllers/take-controller.ts
+++ b/server/src/controllers/take-controller.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from 'express';
+import { TakeService } from '../services/take-service';
+import { successApiResponse } from '../utils/api-response';
+import { BadRequest } from '../errors/bad-request';
+import { AuthenticatedRequest } from '../models/auth-request';
+
+export class TakeController {
+  private takeService: TakeService;
+
+  constructor(takeService: TakeService) {
+    this.takeService = takeService;
+  }
+
+  getAll = async (_req: Request, res: Response): Promise<void> => {
+    const results = await this.takeService.getAll();
+
+    return successApiResponse(
+      res,
+      200,
+      results,
+      'Takes retrieved succesfully!',
+    );
+  };
+
+  getById = async (req: Request, res: Response): Promise<void> => {
+    const takeId = Number(req.params.id);
+
+    if (isNaN(takeId)) {
+      throw new BadRequest('Invalid ID');
+    }
+
+    const result = await this.takeService.getById(takeId);
+
+    return successApiResponse(res, 200, result, 'Role retrieved succesfully!');
+  };
+
+  create = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const { content } = req.body;
+    const { user } = req;
+
+    if (!content) {
+      throw new BadRequest('Take content was not provided');
+    }
+
+    if (!user?.userId) {
+      throw new BadRequest('User id was not provided');
+    }
+
+    const result = await this.takeService.create(content, user.userId);
+
+    return successApiResponse(res, 201, result, 'Take succesfully created!');
+  };
+
+  updateById = async (req: Request, res: Response): Promise<void> => {
+    const takeId = Number(req.params.id);
+    const { content } = req.body;
+
+    if (isNaN(takeId)) {
+      throw new BadRequest('Invalid ID');
+    }
+
+    const result = await this.takeService.updateById(takeId, content);
+
+    return successApiResponse(res, 200, result, 'Take updated succesfully!');
+  };
+
+  deleteById = async (req: Request, res: Response): Promise<void> => {
+    const takeId = Number(req.params.id);
+
+    if (isNaN(takeId)) {
+      throw new BadRequest('Invalid ID');
+    }
+
+    const result = await this.takeService.deleteById(takeId);
+
+    return successApiResponse(res, 200, result, 'Take deleted succesfully!');
+  };
+}

--- a/server/src/routes/take-route.ts
+++ b/server/src/routes/take-route.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import { TakeService } from '../services/take-service';
+import { TakeController } from '../controllers/take-controller';
+import { asyncWrapper } from '../utils/async-wrapper';
+import { PrismaClient } from '@prisma/client';
+import { authenticateToken } from '../middleware/auth-middleware';
+
+export const createTakeRouter = (prisma: PrismaClient) => {
+  const router = express.Router();
+  const takeService = new TakeService(prisma);
+  const takeController = new TakeController(takeService);
+
+  router.get('/', asyncWrapper(takeController.getAll));
+  router.get('/:id', asyncWrapper(takeController.getById));
+  router.post('/', authenticateToken, asyncWrapper(takeController.create));
+  router.put(
+    '/:id',
+    authenticateToken,
+    asyncWrapper(takeController.updateById),
+  );
+  router.delete(
+    '/:id',
+    authenticateToken,
+    asyncWrapper(takeController.deleteById),
+  );
+
+  return router;
+};

--- a/server/src/services/take-service.ts
+++ b/server/src/services/take-service.ts
@@ -1,0 +1,57 @@
+import { Take } from '../generated/prisma';
+import { NotFound } from '../errors/not-found';
+import { PrismaClient } from '@prisma/client';
+
+export class TakeService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getAll(): Promise<Take[]> {
+    const takes = await this.prisma.take.findMany();
+
+    return takes;
+  }
+
+  async getById(id: number): Promise<Take | null> {
+    const take = await this.prisma.take.findUnique({
+      where: { id: id },
+    });
+
+    if (!take) {
+      throw new NotFound('Take not found!');
+    }
+
+    return take;
+  }
+
+  async create(content: string, createdBy: number): Promise<Take> {
+    const take = await this.prisma.take.create({
+      data: {
+        content,
+        createdBy,
+      },
+    });
+
+    return take;
+  }
+
+  async updateById(id: number, content: string): Promise<Take> {
+    try {
+      return await this.prisma.take.update({
+        where: { id },
+        data: { content },
+      });
+    } catch (err: any) {
+      if (err.code === 'P2025') throw new NotFound('Take not found!');
+      throw err;
+    }
+  }
+
+  async deleteById(id: number): Promise<Take> {
+    try {
+      return await this.prisma.take.delete({ where: { id } });
+    } catch (err: any) {
+      if (err.code === 'P2025') throw new NotFound('Take not found!');
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
- `take-service.ts` was created, this is using DI to get the prisma client injected from the controller.
- `take-controller.ts` just take care about some less validation, db related error are handle in the service.
- `take-route.ts` has `createTakeRouter` which just return the routes already created.

The approach used in this endpoint is much cleaner and scalable so we might need to use it in other endpoints.



